### PR TITLE
Set of improovements (Get rid of most relative UOMs etc.)

### DIFF
--- a/Dog.scad
+++ b/Dog.scad
@@ -318,6 +318,6 @@ module customization_figures()
 	    difference()
 	    {
 	        cube([testCubeWidth, testCubeWidth, sideWidth], center=true);
-	        cylinder(h = sideWidth, d = wheelShaftDiameter, center=true, $fn=360);
+	        cylinder(h = sideWidth + delta, d = wheelShaftDiameter, center=true, $fn=360);
 	    }
 }

--- a/Dog.scad
+++ b/Dog.scad
@@ -98,7 +98,7 @@ module dog_for_producing()
     if (showWheels)
     {
         translate([0.35 * sideScaledLength, sideScaledHeigh * 0.5, 0])
-            dog_wheel_spacer();
+            dog_wheel_spacer(wheelSpacerHeight);
     }
 
     translate([-0.17 * sideScaledLength, sideScaledHeigh * 1.27, wheelWidth * 0.5])
@@ -219,14 +219,14 @@ module dog_wheels()
     }
 }
 
-module dog_wheel_spacer()
+module dog_wheel_spacer(currentHeight)
 {
     color(wheelColor, 1.0)
     difference()
     {
-        cylinder(h=wheelSpacerHeight, d = wheelSpacerDiameter, $fn=360);
+		cylinder(h=currentHeight, d = wheelSpacerDiameter, $fn=360);
         translate([0,0, -delta * 0.5])
-            cylinder(h=wheelSpacerHeight + delta, d=wheelShaftDiameter, $fn=360);
+            cylinder(h=currentHeight + delta, d=wheelShaftDiameter, $fn=360);
     }
 }
 
@@ -238,7 +238,7 @@ module dog_wheel_assembled()
         dog_wheel();
         
         translate([0, 0, -wheelWidth * 0.5-wheelSpacerHeight])
-                dog_wheel_spacer();
+                dog_wheel_spacer(wheelSpacerHeight);
     }       
 }
 
@@ -247,8 +247,7 @@ module dog_wheel()
 	color(wheelColor, 1.0)
     if (showWheels)
     {
-        translate([0, 0, wheelWidth * 0.5])
-            dog_wheel_spacer();
+        dog_wheel_spacer(wheelSpacerHeight + wheelWidth * 0.5);
         difference()
         {
             rotate([0, 0, - $t * 360 * 6])

--- a/Dog.scad
+++ b/Dog.scad
@@ -3,10 +3,10 @@ expectedLength = 112;
 renderingType = "Preview";//["Preview", "Producing"]
 
 /* [Screws] */
-screwHoleDiameter = 3;
-screwHeaderDiameter = 6;
+screwHoleDiameter = 3.35;
+screwHeaderDiameter = 6.2;
 screwHeaderDepth = 2.4;
-screwNutDiameter = 6.5;
+screwNutDiameter = 6.53;
 screwNutDepth = 2.4;
 
 /* [Debug] */
@@ -15,7 +15,7 @@ showDebugFigures = false;
 /* [Wheels] */
 showWheels = true;
 wheelSpacerHeight = 2.8059138096;
-wheelShaftDiameter = 5;
+wheelShaftDiameter = 4.7;
 wheelSpacerDiameter = 8.01392;
 wheelSpacerOffset = 0.6;
 wheelColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]

--- a/Dog.scad
+++ b/Dog.scad
@@ -16,7 +16,7 @@ showDebugFigures = false;
 
 /* [Wheels] */
 showWheels = true;
-wheelWidth = 21;
+wheelSpacerHeight = 14.0052;
 wheelShaftDiameter = 5;
 wheelSpacerDiameter = 40;
 wheelSpacerOffset = 0.6;
@@ -46,9 +46,11 @@ sideMountingHoleCoords = [[165, 35], [-48.3, -25], [-215, 80], [-230, 15]];
 
 wheelCoords = [[-159.7, -115.33], [64.25, -111.8]];
 
+
 // calculations
 scaleFactor = expectedLength / sideRealLength;
-wheelSpacerHeight = (mediumWidth - wheelWidth - 2 * wheelSpacerOffset / scaleFactor) * 0.5;
+wheelWidth = (mediumWidth -  2 * (wheelSpacerHeight + wheelSpacerOffset / scaleFactor));
+
 
 // debug information
 echo();echo();

--- a/Dog.scad
+++ b/Dog.scad
@@ -1,4 +1,3 @@
-
 /* [General] */
 expectedLength = 112;
 renderingType = "Preview";//["Preview", "Producing"]
@@ -12,7 +11,6 @@ screwNutDepth = 2.4;
 
 /* [Debug] */
 showDebugFigures = false;
-
 
 /* [Wheels] */
 showWheels = true;
@@ -32,9 +30,6 @@ sideColor = "Brown";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, 
 showMedium = true;
 mediumWidth = 11.01914;
 mediumColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
-
-
-
 
 /* [Hidden] */
 sideShift = 15.01;
@@ -60,17 +55,22 @@ wheelCoords = [[-159.7 * scaleFactor, -115.33 * scaleFactor],
 
 // debug information
 echo();echo();
-echo("Scale factor: ", scaleFactor);
+echo("Results: ");
+echo("  Scale factor: ", scaleFactor);
 echo();
-echo("Result wheel diameter ", wheelRealDiameter * scaleFactor);
-echo("Result wheel spacer wall thickness", (wheelSpacerDiameter - wheelShaftDiameter) * 0.5);
+echo("  Wheel: ");
+echo("      Diameter: ", wheelRealDiameter * scaleFactor);
+echo("      Spacer wall thickness: ", (wheelSpacerDiameter - wheelShaftDiameter) * 0.5);
+echo("      Width: ", wheelWidth);
 echo();
-echo("Result side length ", sideRealLength * scaleFactor);
-echo("Result side heigh ", sideRealHeight * scaleFactor);
+echo("  Side: ");
+echo("      Total length: ", sideRealLength * scaleFactor);
+echo("      Total height: ", sideRealHeight * scaleFactor);
 echo();
-echo("Result total width: ", 2 * sideWidth + mediumWidth);
+echo("  Others: ");
+echo("      Total width: ", 2 * sideWidth + mediumWidth);
+echo("      Screw rod length: ", 2 * sideWidth + mediumWidth - screwHeaderDepth);
 echo();echo();
-
 
 
 if (renderingType == "Producing")

--- a/Dog.scad
+++ b/Dog.scad
@@ -16,22 +16,24 @@ showDebugFigures = false;
 
 /* [Wheels] */
 showWheels = true;
-wheelSpacerHeight = 14.0052;
+wheelSpacerHeight = 2.8059138096;
 wheelShaftDiameter = 5;
-wheelSpacerDiameter = 40;
+wheelSpacerDiameter = 8.01392;
 wheelSpacerOffset = 0.6;
 wheelColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
 
 /* [Sides] */
 showLeftSide = true;
 showRightSide = true;
-sideWidth = 25;
+sideWidth = 5.00871;
 sideColor = "Brown";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
 
 /* [Medium] */
 showMedium = true;
-mediumWidth = 55;
+mediumWidth = 11.01914;
 mediumColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
+
+
 
 
 /* [Hidden] */
@@ -40,72 +42,73 @@ wheelRealDiameter = 212;
 sideRealLength = 559.026;
 sideRealHeight = 329.776;
 delta = 0.05;
-wheelPlaceDiameter = wheelRealDiameter * 1.05;
-
-sideMountingHoleCoords = [[165, 35], [-48.3, -25], [-215, 80], [-230, 15]];
-
-wheelCoords = [[-159.7, -115.33], [64.25, -111.8]];
 
 
 // calculations
 scaleFactor = expectedLength / sideRealLength;
-wheelWidth = (mediumWidth -  2 * (wheelSpacerHeight + wheelSpacerOffset / scaleFactor));
+wheelWidth = (mediumWidth -  2 * (wheelSpacerHeight + wheelSpacerOffset));
+wheelPlaceDiameter = wheelRealDiameter * scaleFactor * 1.05;
 
+//TODO refactor it, too many repeating of scaleFactor
+sideMountingHoleCoords = [[165 * scaleFactor, 35 * scaleFactor], 
+    [-48.3 * scaleFactor, -25 * scaleFactor], 
+    [-215 * scaleFactor, 80 * scaleFactor], 
+    [-230 * scaleFactor, 15 * scaleFactor]];
+
+wheelCoords = [[-159.7 * scaleFactor, -115.33 * scaleFactor],
+    [64.25 * scaleFactor, -111.8 * scaleFactor]];
 
 // debug information
 echo();echo();
-/*echo("Side shift: ", sideShift);
-echo();*/
 echo("Scale factor: ", scaleFactor);
 echo();
 echo("Result wheel diameter ", wheelRealDiameter * scaleFactor);
-echo("Result wheel spacer wall thickness", (wheelSpacerDiameter * scaleFactor - wheelShaftDiameter) / 2);
+echo("Result wheel spacer wall thickness", (wheelSpacerDiameter - wheelShaftDiameter) * 0.5);
 echo();
 echo("Result side length ", sideRealLength * scaleFactor);
 echo("Result side heigh ", sideRealHeight * scaleFactor);
-echo("Result side width: ", sideWidth * scaleFactor);
 echo();
-echo("Result medium width: ", mediumWidth * scaleFactor);
-echo();
-echo("Result total width: ", (2 * sideWidth + mediumWidth) * scaleFactor);
+echo("Result total width: ", 2 * sideWidth + mediumWidth);
 echo();echo();
 
 
-scale([scaleFactor, scaleFactor, scaleFactor])
-{
-    if (renderingType == "Producing")
-        dog_for_producing();
-    else
-        dog_for_preview();
-}
+
+if (renderingType == "Producing")
+    dog_for_producing();
+else
+    dog_for_preview();
+
 
 module dog_for_producing()
 {
+    sideScaledHeigh = sideRealHeight * scaleFactor;
+    sideScaledLength = sideRealLength * scaleFactor;
+
     translate([0, 0, sideWidth * 0.5])
         rotate([0, 180, 180])
             dog_left_side();
     
-    translate([0, sideRealHeight * 0.95, sideWidth * 0.5])
+    translate([0, sideScaledHeigh * 0.95, sideWidth * 0.5])
         dog_right_side();
     
-    translate([+sideRealLength * 0.6, sideRealHeight * 0.3, mediumWidth * 0.5])
+    translate([+sideScaledLength * 0.6, sideScaledHeigh * 0.3, mediumWidth * 0.5])
         rotate([0, 0, 270]) 
             dog_medium();
     
-    translate([0.35 * sideRealLength, sideRealHeight * 0.5, 0])
+    translate([0.35 * sideScaledLength, sideScaledHeigh * 0.5, 0])
         dog_wheel_spacer();
 
-    translate([-0.17 * sideRealLength, sideRealHeight * 1.27, wheelWidth * 0.5])
+    translate([-0.17 * sideScaledLength, sideScaledHeigh * 1.27, wheelWidth * 0.5])
         dog_wheel();
     
-    translate([-0.3 * sideRealLength, -sideRealHeight * 0.5, 0]) 
+    translate([-0.3 * sideScaledLength, -sideScaledHeigh * 0.5, 0]) 
         rotate([0, 0, 90]) 
         	customization_figures();
 }
 
 module dog_for_preview()
 {
-    translate([0, 0, sideRealHeight * 0.65])
+    translate([0, 0, sideRealHeight * 0.65 * scaleFactor])
 	rotate([90,0,0])
 	{
 	    translate([0, 0, sideWidth * 0.5])
@@ -128,8 +131,9 @@ module dog_medium()
         color(mediumColor, 1.0)
             difference()
             {
-                linear_extrude(height = mediumWidth, convexity=2, center = true)
-                    import(file = "dog_4_scad_medium.svg", $fn=360, center = true);
+                scale([scaleFactor, scaleFactor, 1]) 
+                    linear_extrude(height = mediumWidth, convexity=2, center = true)
+                        import(file = "dog_4_scad_medium.svg", $fn=360, center = true);
                 union()
                 {
                     for(coord = sideMountingHoleCoords)
@@ -173,9 +177,10 @@ module dog_side(side)
     color(sideColor, 1.0)
     difference()
     {
-        translate([0, sideShift, 0])
-            linear_extrude(height = sideWidth, convexity=10, center = true)
-                import(file = "dog_4_scad_side.svg", $fn=360, center = true);
+        scale([scaleFactor, scaleFactor, 1]) 
+            translate([0, sideShift, 0])
+                linear_extrude(height = sideWidth, convexity=10, center = true)
+                    import(file = "dog_4_scad_side.svg", $fn=360, center = true);
         union()
         {
             for(coord = sideMountingHoleCoords)
@@ -195,9 +200,10 @@ module dog_side(side)
 
     if (showDebugFigures)
     {
-        translate([0, sideShift, 0])
-            color(undef)
-                cube([sideRealLength, sideRealHeight, sideWidth * 0.5], center = true);
+        color(undef)
+            scale([scaleFactor, scaleFactor, 1])
+                translate([0, sideShift, 0])
+                    cube([sideRealLength, sideRealHeight, sideWidth * 0.5], center = true);
     }
 }
 
@@ -217,7 +223,7 @@ module dog_wheel_spacer()
     {
         cylinder(h=wheelSpacerHeight, d = wheelSpacerDiameter, $fn=360);
         translate([0,0, -delta * 0.5])
-            cylinder(h=wheelSpacerHeight + delta, d=wheelShaftDiameter / scaleFactor, $fn=360);
+            cylinder(h=wheelSpacerHeight + delta, d=wheelShaftDiameter, $fn=360);
     }
 }
 
@@ -243,33 +249,35 @@ module dog_wheel()
         difference()
         {
             rotate([0, 0, - $t * 360 * 6])
-                translate([0.6, -1.1, 0])// centering
-                    linear_extrude(height = wheelWidth, convexity=6, center = true) 
-                        import(file = "dog_4_scad_wheel.svg", center=true, $fn=360);
-            cylinder(h = wheelWidth + delta, d = wheelShaftDiameter / scaleFactor, center = true, $fn = 360);
+                scale([scaleFactor, scaleFactor, 1]) 
+                    translate([0.6, -1.1, 0])// centering
+                        linear_extrude(height = wheelWidth, convexity=6, center = true) 
+                            import(file = "dog_4_scad_wheel.svg", center=true, $fn=360);
+            cylinder(h = wheelWidth + delta, d = wheelShaftDiameter, center = true, $fn = 360);
         }
 
         if (showDebugFigures)
         {
             debug_figure();
             
-            //for centering wheels 
-            //cylinder(h=wheelWidth - 0.5, d = wheelRealDiameter, center=true, $fn=360);
+            //for centering wheels
+            scale([scaleFactor, scaleFactor, 1]) 
+                cylinder(h=wheelWidth - 0.5, d = wheelRealDiameter, center=true, $fn=360);
         }
     }
 }
 
 module screw_hole(height)
 {
-    cylinder(h = height + delta, d = screwHoleDiameter / scaleFactor, center = true, $fn=360);
+    cylinder(h = height + delta, d = screwHoleDiameter, center = true, $fn=360);
 }
 
 module screw_hole_with_groove(height, screwHead)
 {
     screw_hole(height);
     
-    depth = (screwHead ? screwHeaderDepth : screwNutDepth) / scaleFactor;
-    diameter = (screwHead ?  screwHeaderDiameter : screwNutDiameter) / scaleFactor;
+    depth = (screwHead ? screwHeaderDepth : screwNutDepth);
+    diameter = (screwHead ?  screwHeaderDiameter : screwNutDiameter);
     $fn = screwHead ? 360 : 6;
 
     translate([0, 0, sideWidth * 0.5 - depth])
@@ -284,7 +292,7 @@ module debug_figure()
 module customization_figures()
 {
     maxDiameter = max(screwHeaderDiameter, wheelShaftDiameter);
-    testCubeWidth = maxDiameter * 2.5 / scaleFactor;
+    testCubeWidth = maxDiameter * 2.5;
 
     // screw head
     translate([0, testCubeWidth * 1.1, sideWidth * 0.5]) 
@@ -307,6 +315,6 @@ module customization_figures()
 	    difference()
 	    {
 	        cube([testCubeWidth, testCubeWidth, sideWidth], center=true);
-	        cylinder(h = sideWidth / scaleFactor, d = wheelShaftDiameter / scaleFactor, center=true, $fn=360);
+	        cylinder(h = sideWidth, d = wheelShaftDiameter, center=true, $fn=360);
 	    }
 }

--- a/Dog.scad
+++ b/Dog.scad
@@ -94,9 +94,12 @@ module dog_for_producing()
     translate([+sideScaledLength * 0.6, sideScaledHeigh * 0.3, mediumWidth * 0.5])
         rotate([0, 0, 270]) 
             dog_medium();
-    
-    translate([0.35 * sideScaledLength, sideScaledHeigh * 0.5, 0])
-        dog_wheel_spacer();
+
+    if (showWheels)
+    {
+        translate([0.35 * sideScaledLength, sideScaledHeigh * 0.5, 0])
+            dog_wheel_spacer();
+    }
 
     translate([-0.17 * sideScaledLength, sideScaledHeigh * 1.27, wheelWidth * 0.5])
         dog_wheel();

--- a/Dog.scad
+++ b/Dog.scad
@@ -14,21 +14,21 @@ showDebugFigures = false;
 
 /* [Wheels] */
 showWheels = true;
-wheelSpacerHeight = 2.8059138096;
+wheelSpacerHeight = 2.8;
 wheelShaftDiameter = 4.7;
-wheelSpacerDiameter = 8.01392;
+wheelSpacerDiameter = 8.0;
 wheelSpacerOffset = 0.6;
 wheelColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
 
 /* [Sides] */
 showLeftSide = true;
 showRightSide = true;
-sideWidth = 5.00871;
+sideWidth = 5.0;
 sideColor = "Brown";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
 
 /* [Medium] */
 showMedium = true;
-mediumWidth = 11.01914;
+mediumWidth = 11.0;
 mediumColor = "White";// [Black, Blue, Brown, Chartreuse, Green, Magenta, Orange, Purple, Red, Teal, Violet, White, Yellow]
 
 /* [Hidden] */

--- a/Dog.scad
+++ b/Dog.scad
@@ -294,6 +294,7 @@ module debug_figure()
 
 module customization_figures()
 {
+    $fn = 8;
     maxDiameter = max(screwHeaderDiameter, wheelShaftDiameter);
     testCubeWidth = maxDiameter * 2.5;
 
@@ -301,7 +302,7 @@ module customization_figures()
     translate([0, testCubeWidth * 1.1, sideWidth * 0.5]) 
 	    difference()
 	    {
-	        cube([testCubeWidth, testCubeWidth, sideWidth], center=true);
+	        cylinder(h = sideWidth, d = testCubeWidth, center=true);
 	        screw_hole_with_groove(sideWidth, true);
 	    }
 
@@ -309,7 +310,7 @@ module customization_figures()
     translate([0, 0, sideWidth * 0.5]) 
 	    difference()
 	    {
-	        cube([testCubeWidth, testCubeWidth, sideWidth], center=true);
+	        cylinder(h = sideWidth, d = testCubeWidth, center=true);
 	        screw_hole_with_groove(sideWidth, false);
 	    }
 
@@ -317,7 +318,7 @@ module customization_figures()
     translate([0, -testCubeWidth * 1.1, sideWidth * 0.5]) 
 	    difference()
 	    {
-	        cube([testCubeWidth, testCubeWidth, sideWidth], center=true);
+	        cylinder(h = sideWidth, d = testCubeWidth, center=true);
 	        cylinder(h = sideWidth + delta, d = wheelShaftDiameter, center=true, $fn=360);
 	    }
 }


### PR DESCRIPTION
Improvements:

* Get rid of most relative Units of measure
* Wheel width is calculated from spacer and medium part (allow to have the wide wheels) 
* Update README.md
* Fixed wheel slicing problem with Prusa Slicer (a wheel with a built spacer was separating into 2 parts: spacer and wheel)
* Rounded values (except constants and adjustments) to xx.x
* Reduce filament usage for test figures
* Get rid of artifacts on preview for the wheel shaft customization figure
* Adjusted hole sizes (for screws and shafts)
* Wheel spacer is rendered in Producing mode just in case showWheels = true
* Added "Wheel width" and "Screw rod length" to debugging log; Refined debugging log in YAML-like style
